### PR TITLE
Removed const modifier for color variable

### DIFF
--- a/src/java/clearvolume/renderer/opencl/kernels/VolumeRender.cl
+++ b/src/java/clearvolume/renderer/opencl/kernels/VolumeRender.cl
@@ -292,7 +292,8 @@ maxproj_render(					 __global uint	*d_output,
 	
 
 	// lookup in transfer function texture:
-  const float4 color = brightness*read_imagef(transferColor4,transferSampler, (float2)(mappedVal,0.0f));
+	// AW: I deleted the const modifier here; this allows ClearVolume to work on Intel openCL driver
+ float4 color = brightness*read_imagef(transferColor4,transferSampler, (float2)(mappedVal,0.0f));
   
   // Alpha pre-multiply:
   color.x = color.x*color.w;


### PR DESCRIPTION
The const modifier on the float4 color definition at line 295 seems to cause problems with Intel GPUs. I removed that modifier (I have NO idea if this is a bad thing to do) and the kernel now compiles on both Nvidia and Intel GPUs. This means that the ClearVolume FIJI plugin can now work on Intel GPUs, whereas it would crash otherwise.

I am not a java programmer, nor do I know anything about OpenCL development. I don't know if this was a "safe" change. I just wanted to be able to use the ClearVolume plugin on my laptop, and this seemed to work! 